### PR TITLE
Invert parity of env variable `DISABLE_DO_BY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ def say_hello
 end
 ```
 
+Enable DoBy checks by setting `ENABLE_DO_BY=1`.
+(It's made that way so it doesn't run by default on production
+environments. You wouldn't want accidents to happen!)
+
 Before that date, everything will run as normal. After that date, the code will
 raise an exception:
 
 `DoBy::LateTask: 'fix this' is overdue (2014-06-01)`
-
-In your production environment, set `DISABLE_DO_BY=1` to disable checks.
 
 The date can be anything parseable by Ruby's `DateTime.parse` method - `2014-06`, `June`, etc.
 

--- a/lib/do_by.rb
+++ b/lib/do_by.rb
@@ -19,6 +19,6 @@ module DoBy
 end
 
 def TODO(*args)
-  return if ENV['DISABLE_DO_BY']
+  return unless ENV['ENABLE_DO_BY']
   DoBy::Note.new(*args)
 end


### PR DESCRIPTION
DoBy now won't run unless the variable is set. This fixes #2.
